### PR TITLE
Implement basic memorisation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Memorisation-Tool
+# Memorisation Tool
+
+A simple command-line flashcard application using the Leitner system.
+
+## Usage
+
+Add a card:
+
+```bash
+python -m memorisation_tool add "Question" "Answer"
+```
+
+Review due cards:
+
+```bash
+python -m memorisation_tool review
+```
+
+Cards are stored in `cards.json` in the current directory.

--- a/memorisation_tool/__init__.py
+++ b/memorisation_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Simple memorisation tool using the Leitner system."""
+
+from .cli import main
+
+__all__ = ['main']

--- a/memorisation_tool/cli.py
+++ b/memorisation_tool/cli.py
@@ -1,0 +1,55 @@
+import argparse
+from datetime import datetime
+
+from .storage import load_cards, save_cards
+from .models import Flashcard
+
+
+def add_card(question: str, answer: str) -> None:
+    cards = load_cards()
+    cards.append(Flashcard(question=question, answer=answer))
+    save_cards(cards)
+    print('Card added.')
+
+
+def review_cards() -> None:
+    cards = load_cards()
+    now = datetime.utcnow()
+    due_cards = [c for c in cards if c.next_review() <= now]
+    if not due_cards:
+        print('No cards due for review.')
+        return
+    for card in due_cards:
+        print(f'Question: {card.question}')
+        input('Press Enter to see the answer...')
+        print(f'Answer: {card.answer}')
+        resp = input('Did you get it right? [y/N] ').strip().lower()
+        if resp == 'y':
+            card.box = min(card.box + 1, 5)
+        else:
+            card.box = 1
+        card.last_reviewed = now
+    save_cards(cards)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Memorisation Tool')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_parser = subparsers.add_parser('add', help='Add a flashcard')
+    add_parser.add_argument('question')
+    add_parser.add_argument('answer')
+
+    subparsers.add_parser('review', help='Review flashcards')
+
+    args = parser.parse_args(argv)
+    if args.command == 'add':
+        add_card(args.question, args.answer)
+    elif args.command == 'review':
+        review_cards()
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/memorisation_tool/models.py
+++ b/memorisation_tool/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+@dataclass
+class Flashcard:
+    question: str
+    answer: str
+    box: int = 1
+    last_reviewed: datetime = field(default_factory=datetime.utcnow)
+
+    def next_review(self) -> datetime:
+        intervals = {
+            1: timedelta(days=1),
+            2: timedelta(days=3),
+            3: timedelta(days=7),
+            4: timedelta(days=14),
+            5: timedelta(days=30),
+        }
+        return self.last_reviewed + intervals.get(self.box, timedelta(days=30))

--- a/memorisation_tool/storage.py
+++ b/memorisation_tool/storage.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import List
+
+from .models import Flashcard
+
+DATA_FILE = Path('cards.json')
+
+
+def load_cards() -> List[Flashcard]:
+    if not DATA_FILE.exists():
+        return []
+    with DATA_FILE.open('r', encoding='utf-8') as f:
+        data = json.load(f)
+    cards = []
+    for item in data:
+        card = Flashcard(
+            question=item['question'],
+            answer=item['answer'],
+            box=item.get('box', 1),
+            last_reviewed=datetime.fromisoformat(item['last_reviewed'])
+        )
+        cards.append(card)
+    return cards
+
+
+def save_cards(cards: List[Flashcard]) -> None:
+    data = []
+    for card in cards:
+        data.append({
+            'question': card.question,
+            'answer': card.answer,
+            'box': card.box,
+            'last_reviewed': card.last_reviewed.isoformat()
+        })
+    with DATA_FILE.open('w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from memorisation_tool.storage import load_cards, save_cards, DATA_FILE
+from memorisation_tool.models import Flashcard
+
+
+def test_save_and_load(tmp_path):
+    data_file = tmp_path / 'cards.json'
+    import memorisation_tool.storage as storage
+    original = storage.DATA_FILE
+    try:
+        storage.DATA_FILE = data_file
+        cards = [Flashcard('q1', 'a1')]
+        save_cards(cards)
+        assert data_file.exists()
+
+        loaded = load_cards()
+        assert len(loaded) == 1
+        assert loaded[0].question == 'q1'
+        assert loaded[0].answer == 'a1'
+        assert isinstance(loaded[0].last_reviewed, datetime)
+    finally:
+        storage.DATA_FILE = original


### PR DESCRIPTION
## Summary
- create simple Leitner system CLI for flashcards
- store data in JSON via `storage.py`
- basic tests for saving and loading
- document usage in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fad6195d8832ea1caf4c581a108fe